### PR TITLE
Add reusable workflow for running KinD tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,16 @@
+name: E2E # Part of the check name, be careful when changing.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-2.[7-9]
+  push:
+    branches:
+      - main
+      - release-2.[7-9]
+
+jobs:
+  kind-tests:
+    name: Framework KinD # Part of the check name, be careful when changing.
+    uses: ./.github/workflows/kind.yml

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -1,0 +1,149 @@
+name: Framework KinD Workflow
+
+on:
+  workflow_call:
+    inputs:
+      hub_only_component:
+        required: false
+        type: string
+        default: 'false'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests:
+    name: Tests # Part of the check name, be careful when changing.
+
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: localhost:5000
+    strategy:
+      # Don't skip all tests if one fails - others may still have useful info
+      fail-fast: false
+      matrix:
+        # Run tests against an old and a new version of kubernetes
+        # (for reference, OCP 4.6 runs Kubernetes v1.19)
+        # KinD tags are listed at https://hub.docker.com/r/kindest/node/tags
+        kind:
+          - 'v1.19.16'
+          - 'latest'
+        deployOnHub:
+          - 'true'
+          - 'false'
+
+    steps:
+    - name: Checkout Component Repository
+      # Checkout a specific component when called from another repository
+      if: ${{ github.event.repository.name != 'governance-policy-framework' }}
+      uses: actions/checkout@v2
+      with:
+        # `repository` is inferred as the "caller" repository 
+        path: component
+        # `ref` is inferred as the new commit in the "caller" repository
+
+    - name: Checkout Policy Framework
+      # Checkout a stable branch when called from another repository
+      if: ${{ github.event.repository.name != 'governance-policy-framework' }}
+      uses: actions/checkout@v2
+      with:
+        repository: stolostron/governance-policy-framework
+        path: framework
+        ref: ${{ github.event.pull_request.base.ref }} # like main or release-*
+
+    - name: Checkout Policy Framework
+      # Checkout like "usual" when called from this repository
+      if: ${{ github.event.repository.name == 'governance-policy-framework' }}
+      uses: actions/checkout@v2
+      with:
+        # `repository` is inferred as the "caller" repository 
+        path: framework
+        # `ref` is inferred as the new commit
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: framework/go.mod
+
+    - name: Bootstrap the KinD Cluster
+      working-directory: framework
+      env:
+        deployOnHub: ${{ matrix.deployOnHub }}
+        KIND_VERSION: ${{ matrix.kind }}
+      run: |
+        echo "::group::make e2e-dependencies"
+        make e2e-dependencies
+        echo "::endgroup::"
+
+        echo "::group::make kind-bootstrap-cluster"
+        make kind-bootstrap-cluster
+        echo "::endgroup::"
+
+        echo "::group::kubectl get pods -A"
+        kubectl get pods -A
+        echo "::endgroup::"
+
+        echo "Saving kubeconfig paths for use in other steps"
+        echo "MANAGED_KUBECONFIG=$(pwd)/kubeconfig_managed" >> $GITHUB_ENV
+        echo "HUB_KUBECONFIG=$(pwd)/kubeconfig_hub" >> $GITHUB_ENV
+        echo "HUB_INTERNAL_KUBECONFIG=$(pwd)/kubeconfig_hub_internal" >> $GITHUB_ENV
+
+    - name: Patch Component Image
+      if: ${{ github.event.repository.name != 'governance-policy-framework' }}
+      working-directory: component
+      env:
+        deployOnHub: ${{ matrix.deployOnHub }}
+        HUB_ONLY: ${{ inputs.hub_only_component }}
+        WATCH_NAMESPACE: managed
+      run: |
+        export MANAGED_CONFIG=${MANAGED_KUBECONFIG}
+        export HUB_CONFIG=${HUB_KUBECONFIG}
+        export HUB_CONFIG_INTERNAL=${HUB_INTERNAL_KUBECONFIG}
+
+        if [[ "${deployOnHub}" == "true" ]] || [[ "${HUB_ONLY}" == "true" ]]; then
+          echo "Using KIND_NAME=hub and the hub config as the default kubeconfig"
+          export KIND_NAME=hub
+          export KUBECONFIG=${HUB_KUBECONFIG}
+        else
+          echo "Using KIND_NAME=managed and the managed config as the default kubeconfig"
+          export KIND_NAME=managed
+          export KUBECONFIG=${MANAGED_KUBECONFIG}
+        fi
+
+        echo "::group::make build-images"
+        make build-images
+        echo "::endgroup::"
+
+        echo "::group::make kind-deploy-controller-dev"
+        make kind-deploy-controller-dev
+        echo "::endgroup::"
+
+    - name: Run e2e tests
+      working-directory: framework
+      env:
+        TEST_ARGS: --json-report=report.json --junit-report=report.xml --output-dir=test-output
+      run: |
+        make e2e-test
+
+    - name: Debug
+      if: ${{ failure() }}
+      working-directory: framework
+      run: |
+        make e2e-debug-kind
+        tar -czvf e2e-debug.tar.gz test-output/debug
+
+    - name: Upload Debug Artifacts
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: fw-kind-debug-${{ matrix.kind }}-${{ matrix.deployOnHub }}
+        path: framework/e2e-debug.tar.gz
+
+    - name: Upload Test Reports
+      uses: actions/upload-artifact@v3
+      with:
+        name: fw-kind-report-${{ matrix.kind }}-${{ matrix.deployOnHub }}
+        path: |
+          framework/test-output/report.xml
+          framework/test-output/report.json


### PR DESCRIPTION
Previously, we added actions to many component repositories to run these
tests on their own PRs, helping to ensure things continued to work well
together. This brings that work into this repository, so that those
repositories do not need to maintain the workflow individually.

It also includes new enhancements to improve the experience on GitHub,
for example saving debug information for download during a failure, and
saving test reports for possible future use. These are accessible from
the summary page of the action run.

Finally, it adds a local call of the workflow on pushes and PRs, which
could replace some other tool's invocation of the tests.

Refs:
 - https://github.com/stolostron/backlog/issues/22914

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>