### PR TITLE
Correctly patch components in hosted mode tests

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -93,7 +93,16 @@ jobs:
         make fmt
         git diff --exit-code
         make lint
-
+    
+    - name: Patch Component Image (addon-controller, hosted)
+      # The Framework's Make target will use this version of the addon-controller to deploy components for hosted mode
+      if: ${{ matrix.hosted == 'hosted' && github.event.repository.name == 'governance-policy-addon-controller' }}
+      uses: actions/checkout@v3
+      with:
+        # `repository` is inferred as the "caller" repository 
+        path: framework/governance-policy-addon-controller
+        # `ref` is inferred as the new commit
+  
     - name: Bootstrap the KinD Cluster
       working-directory: framework
       env:
@@ -128,12 +137,11 @@ jobs:
         echo "::endgroup::"
 
     - name: Patch Component Image
-      if: ${{ github.event.repository.name != 'governance-policy-framework' }}
+      if: ${{ github.event.repository.name != 'governance-policy-framework' && matrix.hosted == '' }}
       working-directory: component
       env:
         deployOnHub: ${{ matrix.deployOnHub }}
         HUB_ONLY: ${{ inputs.hub_only_component }}
-        HOSTED: ${{ matrix.hosted }}
       run: |
         if [[ "$RELEASE_BRANCH" != "main" ]]; then
           export TAG=latest-$(echo $RELEASE_BRANCH | cut -d'-' -f 2):
@@ -145,12 +153,7 @@ jobs:
         export HUB_CONFIG=${HUB_KUBECONFIG}
         export HUB_CONFIG_INTERNAL=${HUB_INTERNAL_KUBECONFIG}
 
-        if [[ "${HOSTED}" == "hosted" ]]; then
-          export WATCH_NAMESPACE=cluster2-hosted
-          export KIND_NAMESPACE=cluster2-hosted
-          export KIND_NAME=policy-addon-ctrl1
-          export KUBECONFIG=${HUB_KUBECONFIG}
-        elif [[ "${deployOnHub}" == "true" ]] || [[ "${HUB_ONLY}" == "true" ]]; then
+        if [[ "${deployOnHub}" == "true" ]] || [[ "${HUB_ONLY}" == "true" ]]; then
           export WATCH_NAMESPACE=managed
           export KIND_NAME=hub
           export KUBECONFIG=${HUB_KUBECONFIG}
@@ -168,6 +171,53 @@ jobs:
 
         echo "::group::make kind-deploy-controller-dev"
         make kind-deploy-controller-dev
+        echo "::endgroup::"
+
+    - name: Patch Component Image (hosted)
+      if: ${{ github.event.repository.name != 'governance-policy-framework' && github.event.repository.name != 'governance-policy-addon-controller' && matrix.hosted == 'hosted' }}
+      working-directory: component
+      env:
+        deployOnHub: ${{ matrix.deployOnHub }}
+        HUB_ONLY: ${{ inputs.hub_only_component }}
+      run: |
+        # this image won't actually pushed to quay:
+        export IMAGE_NAME_AND_VERSION=quay.io/governance-policy-framework/component
+
+        echo "::group::build and load image"
+        make build-images
+        export NEW_IMAGE="${IMAGE_NAME_AND_VERSION}:latest"
+        kind load docker-image "${NEW_IMAGE}" --name policy-addon-ctrl1
+        echo "::endgroup::"
+
+        export KUBECONFIG=${HUB_KUBECONFIG}
+
+        echo "::group::hub pods"
+        KUBECONFIG=${HUB_KUBECONFIG} kubectl get pods -A -o 'custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,STARTED:.status.startTime,IMAGE:.spec.containers[0].image'
+        echo "::endgroup::"
+        echo "::group""managed pods"
+        KUBECONFIG=${MANAGED_KUBECONFIG} kubectl get pods -A -o 'custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,STARTED:.status.startTime,IMAGE:.spec.containers[0].image'
+        echo "::endgroup::"
+
+        if [[ "${HUB_ONLY}" == "true" ]]; then
+          # Must be the propagator
+          kubectl -n open-cluster-management set image deployment/governance-policy-propagator "governance-policy-propagator=${NEW_IMAGE}"
+          kubectl -n open-cluster-management rollout status deployment/governance-policy-propagator --timeout=300s || echo "warning, rollout may have failed"
+        else        
+          echo "::group::update the addon-controller to use the new image"
+          # component "foo-bar" becomes "FOO_BAR_IMAGE": 
+          export IMAGE_ENV="$(tr "[:lower:]-" "[:upper:]_" < COMPONENT_NAME)_IMAGE"
+
+          kubectl -n governance-policy-addon-controller-system set env deployment/policy-addon-ctrl-controller-manager "${IMAGE_ENV}=${NEW_IMAGE}"
+          kubectl -n governance-policy-addon-controller-system set env deployment/policy-addon-ctrl-controller-manager --list
+          kubectl -n governance-policy-addon-controller-system rollout status deployment/policy-addon-ctrl-controller-manager --timeout=300s || echo "warning, rollout may have failed"
+          echo "::endgroup::"
+        fi
+        
+        echo "::group::hub pods"
+        KUBECONFIG=${HUB_KUBECONFIG} kubectl get pods -A -o 'custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,STARTED:.status.startTime,IMAGE:.spec.containers[0].image'
+        echo "::endgroup::"
+        echo "::group""managed pods"
+        KUBECONFIG=${MANAGED_KUBECONFIG} kubectl get pods -A -o 'custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,STARTED:.status.startTime,IMAGE:.spec.containers[0].image'
         echo "::endgroup::"
 
     - name: Run e2e tests

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ setup-managedcluster:
 	-kubectl -n $(MANAGED_CLUSTER_NAMESPACE) create secret generic config-policy-controller-managed-kubeconfig --from-file=kubeconfig=$(PWD)/kubeconfig_managed_internal --kubeconfig=kubeconfig_$(HUB_CLUSTER_NAME)
 	-kubectl -n $(MANAGED_CLUSTER_NAMESPACE) create secret generic cert-policy-controller-managed-kubeconfig --from-file=kubeconfig=$(PWD)/kubeconfig_managed_internal --kubeconfig=kubeconfig_$(HUB_CLUSTER_NAME)
 	-kubectl -n $(MANAGED_CLUSTER_NAMESPACE) create secret generic iam-policy-controller-managed-kubeconfig --from-file=kubeconfig=$(PWD)/kubeconfig_managed_internal --kubeconfig=kubeconfig_$(HUB_CLUSTER_NAME)
-	-sed 's/imagetag/$(VERSION_TAG)/g' test/resources/hosted_mode/managed-cluster-addon.yaml | kubectl apply -f- --kubeconfig=kubeconfig_$(HUB_CLUSTER_NAME) -n cluster2
+	-kubectl apply -f- --kubeconfig=kubeconfig_$(HUB_CLUSTER_NAME) -n cluster2
 
 kind-delete-hosted: $(ADDON_CONTROLLER)
 	@cd governance-policy-addon-controller && make kind-bootstrap-delete-clusters 

--- a/test/resources/hosted_mode/managed-cluster-addon.yaml
+++ b/test/resources/hosted_mode/managed-cluster-addon.yaml
@@ -13,20 +13,15 @@ metadata:
   name: config-policy-controller
   annotations:
     addon.open-cluster-management.io/hosting-cluster-name: cluster1
-    addon.open-cluster-management.io/values: '{"global":{"imageOverrides":{"config_policy_controller":"quay.io/stolostron/config-policy-controller:imagetag"}}}'
-
 spec:
   installNamespace: cluster2-hosted
 ---
-
 apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: ManagedClusterAddOn
 metadata:
   name: cert-policy-controller
   annotations:
     addon.open-cluster-management.io/hosting-cluster-name: cluster1
-    addon.open-cluster-management.io/values: '{"args": {"frequency": 10}, "global":{"imageOverrides":{"cert_policy_controller":"quay.io/stolostron/cert-policy-controller:imagetag"}}}'
-
 spec:
   installNamespace: cluster2-hosted
 ---
@@ -37,7 +32,5 @@ metadata:
   namespace: cluster2
   annotations:
     addon.open-cluster-management.io/hosting-cluster-name: cluster1
-    addon.open-cluster-management.io/values: '{"args": {"frequency": 10}, "global":{"imageOverrides":{"iam_policy_controller":"quay.io/stolostron/iam-policy-controller:imagetag"}}}'
 spec:
   installNamespace: cluster2-hosted
-


### PR DESCRIPTION
For the "usual" managed-cluster components, the environment variables in the addon-controller deployment can be updated to use a newly-built container image for the component. For the propagator, that deployment on the hub cluster can be manually updated. For the addon-controller itself, the make target can be "tricked" into using the new code.

Refs:
 - https://issues.redhat.com/browse/ACM-5211